### PR TITLE
Change get to quorum read

### DIFF
--- a/lock/acquire.go
+++ b/lock/acquire.go
@@ -54,7 +54,7 @@ func (locker *EtcdLocker) Acquire(key string, ttl uint64 /*, wait bool*/) (Lock,
 	kapi := ect.NewKeysAPI(locker.client)
 	ctx := context.Background()
 	for !hasLock {
-		res, err := kapi.Get(ctx, key, &ect.GetOptions{Recursive: true, Sort: true})
+		res, err := kapi.Get(ctx, key, &ect.GetOptions{Recursive: true, Sort: true, Quorum: true})
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}


### PR DESCRIPTION
When running against a 3 server etcd cluster we occasionally see the following error:

```
{"level":"error","ts":"2017-05-09T15:27:36Z","msg":"worker.go:113: Failed to acquire lock","name":"xx/engine","action":"Engine","prefix":"/xxx/xxxxx/","worker":"worker4","lock_key":"/xxxx/yyyy/lock","error":"100: Key not found (//xxxx/yyyy) [733215]"}
```
With this change to use a quorum read I no longer see the error.